### PR TITLE
food bank names and lowered font size

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
     <style>
         body { margin: 20; padding: 0; }
         #map { position: absolute; top: 0; bottom: 0; right: 30px; width: 100%; }
+
     </style>
 
     
@@ -501,7 +502,7 @@
                 function (error, image) {
                     if (error) throw error;
                     map.addImage('custom-marker', image);
-                    // Add a GeoJSON source with 2 points
+                    // Add a GeoJSON source 
                     map.addSource('points', {
                         'type': 'geojson',
                         'data': {
@@ -516,7 +517,7 @@
                                         ]
                                     }, 
                                     'properties' : {
-                                        'title': 'Foodbank'
+                                        'title': '7 Hills Community Pantry'
                                     }
                                 }, 
                                 {
@@ -528,7 +529,7 @@
                                         ]
                                     }, 
                                     'properties' : {
-                                        'title': 'Foodbank2'
+                                        'title': 'Alderville First Nation Community Food Bank'
                                     }
                                 },
                                 {
@@ -540,7 +541,7 @@
                                         ]
                                     }, 
                                     'properties' : {
-                                        'title': 'Foodbank3'
+                                        'title': 'Blessing Cupboard Colborne'
                                     }
                                 }, 
                                 {
@@ -552,7 +553,7 @@
                                         ]
                                     }, 
                                     'properties' : {
-                                        'title': 'Foodbank4'
+                                        'title': 'Brighton Fare Share Food Bank'
                                     }
                                 }, 
                                 {
@@ -564,7 +565,7 @@
                                         ]
                                     }, 
                                     'properties' : {
-                                        'title': 'Foodbank5'
+                                        'title': 'Campbellford Fare Share Food Bank'
                                     }
                                 }, 
                                 {
@@ -576,7 +577,7 @@
                                         ]
                                     }, 
                                     'properties' : {
-                                        'title': 'Foodbank6'
+                                        'title': 'Community Health Centres of Northumberland - Food Cupboard'
                                     }
                                 },
                                 {
@@ -588,7 +589,7 @@
                                         ]
                                     }, 
                                     'properties' : {
-                                        'title': 'Foodbank7'
+                                        'title': 'Community Works in Hamilton Township Food Bank'
                                     }
                                 }, 
                                 {
@@ -600,7 +601,7 @@
                                         ]
                                     }, 
                                     'properties' : {
-                                        'title': 'Foodbank8'
+                                        'title': 'Hastings & Roseneath Ministerial Food Bank'
                                     }
                                 }, 
                                 {
@@ -612,7 +613,7 @@
                                         ]
                                     }, 
                                     'properties' : {
-                                        'title': 'Foodbank9'
+                                        'title': 'Meals on Wheels'
                                     }
                                 },
                                 {
@@ -624,7 +625,7 @@
                                         ]
                                     }, 
                                     'properties' : {
-                                        'title': 'Foodbank10'
+                                        'title': 'Northumberland County Food For All'
                                     }
                                 },
                                 {
@@ -636,7 +637,7 @@
                                         ]
                                     }, 
                                     'properties' : {
-                                        'title': 'Foodbank11'
+                                        'title': 'Northumberland Fare Share Food Bank'
                                     }
                                 },
                                 {
@@ -648,7 +649,7 @@
                                         ]
                                     }, 
                                     'properties' : {
-                                        'title': 'Foodbank12'
+                                        'title': 'Northumberland Fare Share Food Banks'
                                     }
                                 },
                                 {
@@ -660,7 +661,7 @@
                                         ]
                                     }, 
                                     'properties' : {
-                                        'title': 'Foodbank13'
+                                        'title': 'Port Hope Salvation Army Community and Family Services'
                                     }
                                 },
                                 {
@@ -672,7 +673,7 @@
                                         ]
                                     }, 
                                     'properties' : {
-                                        'title': 'Foodbank14'
+                                        'title': 'Salvation Army (The) Community Food Cupboard'
                                     }
                                 },
                                 {
@@ -684,7 +685,7 @@
                                         ]
                                     }, 
                                     'properties' : {
-                                        'title': 'Foodbank15'
+                                        'title': 'Salvation Army Community and Family Service'
                                     }
                                 },
                                 {
@@ -696,7 +697,7 @@
                                         ]
                                     }, 
                                     'properties' : {
-                                        'title': 'Foodbank16'
+                                        'title': 'Society of St. Vincent de Paul'
                                     }
                                 },
                             ]
@@ -712,11 +713,12 @@
                             'icon-image': 'custom-marker',
                             // get the title name from the source's "title" property
                             'text-field': ['get','title'],
+                            'text-size': 10,
                             'text-font': [
                                 'Open Sans Semibold',
-                                'Arial Unicode MS Bold'
+                                'Arial Unicode MS Bold',
                             ],
-                            'text-offset': [0, 1.25],
+                            'text-offset': [0, 2],
                             'text-anchor': 'top'
                         }
                     });


### PR DESCRIPTION
Changed food bank names by referring to the Cobourg AGOL map. https://fleming.maps.arcgis.com/home/webmap/viewer.html?webmap=2cb5f6925f5c46b6858c22db658bad03. 
Customized label size from the default size 16 pixels to size 10 pixels and offset to [0,2] instead of the default [0,1.25 ]